### PR TITLE
Bug fix

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,12 @@
+gapctd 2.1.2 (January 17, 2024)
+----------------------------------------------------------------
+
+BUG FIX
+
+- Fix error in lowpass_filter() automatic freq_n selection when
+  freq_n is NULL.
+
+
 gapctd 2.1.1 (December 11, 2023)
 ----------------------------------------------------------------
 

--- a/R/sbe_modules.R
+++ b/R/sbe_modules.R
@@ -176,7 +176,9 @@ lowpass_filter <- function(x,
     return(new_var)
   }
   
-  freq_n <- ifelse(is.numeric(freq_n), freq_n, mode(diff(x@data$timeS)))
+  freq_n <- ifelse(is.numeric(freq_n), 
+                   freq_n, 
+                   as.numeric(names(table(diff(x@data$timeS)))[which.max(table(diff(x@data$timeS)))]))
   
   for(ii in 1:length(variables)) {
     


### PR DESCRIPTION
gapctd 2.1.2 (January 17, 2024)
----------------------------------------------------------------

BUG FIX

- Fix error in lowpass_filter() automatic freq_n selection when
  freq_n is NULL.