### PR TITLE
Handle varying CTD timezone configurations

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: gapctd
 Type: Package
 Title: Process CTD data from bottom trawl surveys
-Version: 2.1.4
+Version: 2.1.5
 Authors@R: c(person("Sean", "Rohan", 
               email = "sean.rohan@noaa.gov", 
               role = c("aut", "cre")),

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,16 @@
+gapctd 2.1.5 (September 4, 2024)
+----------------------------------------------------------------
+
+BUG FIX
+
+- Add numbers0() function from GAPsurvey package. Needed to run
+  convert_ctd_btd() using only gapctd functions.
+  
+IMPROVEMENTS
+
+- Added option to set instrument timezone in wrapp_run_gapctd().
+
+
 gapctd 2.1.4 (August 29, 2024)
 ----------------------------------------------------------------
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -323,3 +323,35 @@ offset_list_to_vector <- function(offset_list, variables) {
   return(out)
   
 }
+
+
+#' Make numbers the same length preceded by 0s
+#'
+#' @param x a single or vector of values that need to be converted from something like 1 to "001"
+#' @param number_places default = NA. If equal to NA, the function will take use the longest length of a value provided in x (example 1). If equal to a number, it will make sure that every number is the same length of number_places (example 2) or larger (if a value of x has more places than number_places(example 3)).
+#'
+#' @noRd
+#' @return A string of the values in x preceeded by "0"s
+#'
+#' @examples
+#' # example 1
+#' numbers0(x = c(1,11,111))
+#' # example 2
+#' numbers0(x = c(1,11,111), number_places = 4)
+#' # example 3
+#' numbers0(x = c(1,11,111), number_places = 2)
+numbers0 <- function (x, number_places = NA) {
+  x<-as.numeric(x)
+  xx <- rep_len(x = NA, length.out = length(x))
+  if (is.na(number_places)){
+    number_places <- max(nchar(x))
+  }
+  for (i in 1:length(x)) {
+    xx[i] <- paste0(ifelse(number_places<nchar(x[i]),
+                           "",
+                           paste(rep_len(x = 0,
+                                         length.out = number_places-nchar(x[i])),
+                                 collapse = "")), as.character(x[i]))
+  }
+  return(xx)
+}

--- a/man/append_haul_data.Rd
+++ b/man/append_haul_data.Rd
@@ -4,14 +4,14 @@
 \alias{append_haul_data}
 \title{Find cast times and metadata for a haul (R workflow)}
 \usage{
-append_haul_data(x, haul_df, ctd_tz = "America/Anchorage")
+append_haul_data(x, haul_df, ctd_tzone = "America/Anchorage")
 }
 \arguments{
 \item{x}{oce object}
 
 \item{haul_df}{data.frame containing haul metadata}
 
-\item{ctd_tz}{timezone for the ctd as a character vector or numeric}
+\item{ctd_tzone}{timezone for the ctd as a character vector or numeric}
 }
 \value{
 A data.frame with haul metadata and cast times.

--- a/man/run_gapctd.Rd
+++ b/man/run_gapctd.Rd
@@ -8,7 +8,7 @@ run_gapctd(
   x,
   haul_df,
   return_stage = "full",
-  ctd_tz = "America/Anchorage",
+  ctd_tzone = "America/Anchorage",
   ctm_pars = list(),
   align_pars = c(),
   cal_rds_path = NULL,
@@ -22,7 +22,7 @@ run_gapctd(
 
 \item{return_stage}{Character vector denoting which stages of processing should be included in the output (options "typical", "split", "align", "tmcorrect", "full"). Can return multiple stages simultaneously. Default = "full"}
 
-\item{ctd_tz}{timezone for CTD as a character vector or numeric that is valid for POSIXct.}
+\item{ctd_tzone}{timezone for CTD as a character vector or numeric that is valid for POSIXct.}
 
 \item{ctm_pars}{Used for remedial cell thermal mass corrections. Optional list of parameters to use for cell thermal mass correction. Must contain alpha_C and beta_C.}
 

--- a/man/wrapper_run_gapctd.Rd
+++ b/man/wrapper_run_gapctd.Rd
@@ -11,7 +11,8 @@ wrapper_run_gapctd(
   vessel = NULL,
   cruise = NULL,
   channel = NULL,
-  racebase_tzone = "America/Anchorage"
+  racebase_tzone = "America/Anchorage",
+  ctd_tzone = "America/Anchorage"
 )
 }
 \arguments{
@@ -28,6 +29,8 @@ wrapper_run_gapctd(
 \item{channel}{Optional. RODBC channel; only used when haul_df = NULL.}
 
 \item{racebase_tzone}{Time zone for events and start_time in racebase/race_data tables. Passed to get_haul_data()}
+
+\item{ctd_tzone}{Time zone for CTD events. Passed to run_gapctd().}
 }
 \value{
 Writes rds files with cast data to /output/[processing_method]


### PR DESCRIPTION
gapctd 2.1.5 (September 4, 2024)
----------------------------------------------------------------

BUG FIX

- Add numbers0() function from GAPsurvey package. Needed to run
  convert_ctd_btd() using only gapctd functions.
  
IMPROVEMENTS

- Added option to set instrument timezone in wrapp_run_gapctd().